### PR TITLE
Fix test error & Drop all existing tables after the test

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "postinstall": "npm -s run generate",
     "migrate:save": "dotenv -e ./dotenv/prod.env -- prisma migrate save --experimental",
     "migrate:up": "dotenv -e ./dotenv/prod.env -- prisma migrate up --experimental",
+    "migrate:down": "dotenv -e ./dotenv/prod.env -- prisma migrate down 1 --experimental",
     "studio": "prisma studio --experimental"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "ts-yoga-prisma",
+  "name": "ts-apollo-prisma",
   "version": "1.0.0",
-  "description": "Typescript yoga prisma boilerplate",
-  "repository": "https://github.com/dooboolab/ts-yoga-prisma",
+  "description": "Typescript apollo prisma boilerplate",
+  "repository": "https://github.com/dooboolab/ts-apollo-prisma",
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development ts-node-dev --no-notify --respawn --transpileOnly src/server.ts",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm -s run clean && npm -s run generate && tsc",
     "lint": "eslint src/**/**/*.ts && eslint tests/**/**/*.ts",
     "tsc": "tsc",
-    "test": "dotenv -e ./dotenv/test.env -- prisma migrate up --experimental && yarn generate && NODE_ENV=test jest --runInBand --detectOpenHandles",
+    "test": "dotenv -e ./dotenv/test.env -- prisma migrate up --experimental && yarn generate && NODE_ENV=test jest --runInBand --detectOpenHandles --forceExit",
     "generate:test": "npm -s run generate:prisma:test && npm -s run generate:nexus:test",
     "generate:prisma:test": "dotenv -e ./dotenv/test.env -- prisma generate",
     "generate:nexus:test": "dotenv -e ./dotenv/test.env  -- ts-node --transpile-only src/schema",

--- a/tests/testSetup.ts
+++ b/tests/testSetup.ts
@@ -1,8 +1,10 @@
 import { Http2Server } from 'http2';
+import { PrismaClient } from '@prisma/client';
 import { createApp } from '../src/app';
 import express from 'express';
 import { startServer } from '../src/server';
 
+const prisma = new PrismaClient();
 const port = 4000;
 let server: Http2Server;
 export const testHost = `http://localhost:${port}/graphql`;
@@ -14,5 +16,6 @@ beforeAll(async (done) => {
 });
 
 afterAll(async () => {
+  await prisma.raw('DROP schema test CASCADE');
   server.close();
 });

--- a/tests/testSetup.ts
+++ b/tests/testSetup.ts
@@ -7,9 +7,10 @@ const port = 4000;
 let server: Http2Server;
 export const testHost = `http://localhost:${port}/graphql`;
 
-beforeAll(async () => {
+beforeAll(async (done) => {
   const app: express.Application = createApp();
   server = await startServer(app);
+  done();
 });
 
 afterAll(async () => {


### PR DESCRIPTION
### Issues

- Fix jest's open handle error ('TCPSERVERWRAP')
- Drop all existing tables after the test by sending raw SQL query


### Reference 

https://github.com/visionmedia/supertest/issues/520
https://github.com/prisma/prisma/discussions/2409

<br />
<br />

ps. To be honest, I don't know how 'done()' could solve the open handle problem. Any idea?

