### PR TITLE
Add scalarType 'GenderScalar' and asNexusMethod 'gender'

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -28,6 +28,8 @@ enum Gender {
   Male
 }
 
+scalar GenderScalar
+
 type Mutation {
   createDraft(content: String, title: String!): Post!
   deletePost(id: Int!): Post
@@ -101,6 +103,7 @@ input UserCreateInput {
 input UserUpdateInput {
   birthday: Date
   email: String
+  gender: GenderScalar
   name: String
   nickname: String
   phone: String

--- a/src/types/models/Scalar.ts
+++ b/src/types/models/Scalar.ts
@@ -1,4 +1,4 @@
-import { asNexusMethod, enumType } from '@nexus/schema';
+import { asNexusMethod, enumType, scalarType } from '@nexus/schema';
 
 import { GraphQLDate } from 'graphql-iso-date';
 import { GraphQLUpload } from 'graphql-upload';
@@ -13,7 +13,23 @@ export const Gender = enumType({
   members: ['Male', 'Female'],
 });
 
+enum GenderType {
+  Male = 'Male',
+  Female = 'Female',
+}
+export const GenderScalar = scalarType({
+  name: 'GenderScalar',
+  asNexusMethod: 'gender',
+  parseValue(value: GenderType): GenderType {
+    if (GenderType[value]) {
+      return value;
+    }
+  },
+  serialize(value) {
+    return value;
+  },
+});
+
 export const Upload = GraphQLUpload;
 export const DateTime = GraphQLDate;
 export const GQLDate = asNexusMethod(GraphQLDate, 'date');
-// export const GenderEnum = asNexusMethod(Gender, 'gender');

--- a/src/types/resolvers/Mutation.ts
+++ b/src/types/resolvers/Mutation.ts
@@ -32,6 +32,7 @@ export const UserUpdateInputType = inputObjectType({
     t.date('birthday');
     t.string('phone');
     t.string('statusMessage');
+    t.gender('gender');
   },
 });
 

--- a/tests/queries.ts
+++ b/tests/queries.ts
@@ -24,6 +24,7 @@ export const updateProfileMutation = /* GraphQL */`
   mutation updateProfile($user: UserUpdateInput) {
     updateProfile(user: $user) {
       name
+      gender
     }
   }
 `;

--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -79,13 +79,29 @@ describe('Resolver - Mutation', () => {
       const variables = {
         user: {
           name: 'HelloBro',
+          gender: 'Female',
         },
       };
 
       const response = await client.request(updateProfileMutation, variables);
       expect(response).toHaveProperty('updateProfile');
       expect(response.updateProfile).toHaveProperty('name');
+      expect(response.updateProfile).toHaveProperty('gender');
       expect(response.updateProfile.name).toEqual(variables.user.name);
+      expect(response.updateProfile.gender).toEqual(variables.user.gender);
+    });
+
+    it('should throw error when invalid gender value is given', async () => {
+      const variables = {
+        user: {
+          name: 'HelloBro',
+          gender: 'Woman',
+        },
+      };
+
+      expect(async () => {
+        await client.request(updateProfileMutation, variables);
+      }).rejects.toThrow();
     });
 
     it('should create auth user`s draft', async () => {


### PR DESCRIPTION
## Description
- Define scalarType 'GenderScalar'
- Use asNexusMethod 'gender' in UserUpdateInputType.
- Add test case of updateProfileMutation

There is no more typeError now. 
And also the server respond with 400 error when the wrong value is given to 'gender' field of 'updateProfile' mutation argument.


## Issues

I left enumType 'Gender' just in case as below. But, on the other hand, it seems that we won't use it anymore.
I'd like to hear your opinions.

_src/models/Scalar.ts_
```
...
export const Gender = enumType({
  name: 'Gender',
  members: ['Male', 'Female'],
});
...
```


## Checklist
Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes ([x]). This will ensure a smooth and quick review process.

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] Run yarn lint && yarn tsc
- [x] I am willing to follow-up on review comments in a timely manner.