### PR TITLE
Add scalarType 'Gender' and asNexusMethod 'gender'

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -23,10 +23,7 @@ scalar Date
 
 scalar DateTime
 
-enum Gender {
-  Female
-  Male
-}
+scalar Gender
 
 type Mutation {
   createDraft(content: String, title: String!): Post!
@@ -101,6 +98,7 @@ input UserCreateInput {
 input UserUpdateInput {
   birthday: Date
   email: String
+  gender: Gender
   name: String
   nickname: String
   phone: String

--- a/src/types/models/Scalar.ts
+++ b/src/types/models/Scalar.ts
@@ -1,4 +1,4 @@
-import { asNexusMethod, enumType } from '@nexus/schema';
+import { asNexusMethod, enumType, scalarType } from '@nexus/schema';
 
 import { GraphQLDate } from 'graphql-iso-date';
 import { GraphQLUpload } from 'graphql-upload';
@@ -8,12 +8,23 @@ export const AuthType = enumType({
   members: ['Email', 'Facebook', 'Google', 'Apple'],
 });
 
-export const Gender = enumType({
+enum GenderType {
+  Male = 'Male',
+  Female = 'Female',
+}
+export const Gender = scalarType({
   name: 'Gender',
-  members: ['Male', 'Female'],
+  asNexusMethod: 'gender',
+  parseValue(value: GenderType): GenderType {
+    if (GenderType[value]) {
+      return value;
+    }
+  },
+  serialize(value) {
+    return value;
+  },
 });
 
 export const Upload = GraphQLUpload;
 export const DateTime = GraphQLDate;
 export const GQLDate = asNexusMethod(GraphQLDate, 'date');
-// export const GenderEnum = asNexusMethod(Gender, 'gender');

--- a/src/types/resolvers/Mutation.ts
+++ b/src/types/resolvers/Mutation.ts
@@ -32,6 +32,7 @@ export const UserUpdateInputType = inputObjectType({
     t.date('birthday');
     t.string('phone');
     t.string('statusMessage');
+    t.gender('gender');
   },
 });
 

--- a/tests/setup/queries.ts
+++ b/tests/setup/queries.ts
@@ -24,6 +24,7 @@ export const updateProfileMutation = /* GraphQL */`
   mutation updateProfile($user: UserUpdateInput) {
     updateProfile(user: $user) {
       name
+      gender
     }
   }
 `;

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -72,6 +72,7 @@ describe('Resolver - User', () => {
     const variables = {
       user: {
         name: 'HelloBro',
+        gender: 'Male',
       },
     };
 
@@ -79,7 +80,22 @@ describe('Resolver - User', () => {
       const response = await client.request(updateProfileMutation, variables);
       expect(response).toHaveProperty('updateProfile');
       expect(response.updateProfile).toHaveProperty('name');
+      expect(response.updateProfile).toHaveProperty('gender');
       expect(response.updateProfile.name).toEqual(variables.user.name);
+      expect(response.updateProfile.gender).toEqual(variables.user.gender);
+    });
+
+    it('should throw error when invalid gender value is given', async () => {
+      const variables = {
+        user: {
+          name: 'HelloBro',
+          gender: 'Woman',
+        },
+      };
+
+      expect(async () => {
+        await client.request(updateProfileMutation, variables);
+      }).rejects.toThrow();
     });
 
     it('should query me and get updated name', async () => {


### PR DESCRIPTION
## Description
- Define scalarType 'Gender'
- Use asNexusMethod 'gender' in UserUpdateInputType.
- Add test case of updateProfileMutation

There is no more typeError now. 
And also the server respond with 400 error when the wrong value is given to 'gender' field of 'updateProfile' mutation argument.



## Checklist
Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes ([x]). This will ensure a smooth and quick review process.

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] Run yarn lint && yarn tsc
- [x] I am willing to follow-up on review comments in a timely manner.